### PR TITLE
Refactoring, output markdown table for comparative timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The benchmarks which are monitored are
 - IBD up to some height from a local peer or from the P2P network
 - Reindex up to some height
 
-The Python script (`runner/run_bench.py`) may be used as a standalone script
+The Python script (`bitcoinperf`) may be used as a standalone script
 (in conjunction with the Docker configuration) to benchmark and compare
 different Bitcoin commits locally - without necessarily writing to a remote
 codespeed instance.
@@ -39,7 +39,7 @@ $ docker-compose up -d codespeed synced
 # Compare v0.16.0 to the current tip
 
 $ docker-compose run --rm bench \
-    ./runner/run_bench.py --commits "v0.16.0,master"
+    bitcoinperf --commits "v0.16.0,master"
     --no-clean=1 \
     --run-counts ibd:3 \
     --benches-to-run gitclone,build,ibd \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,19 +6,11 @@ services:
   # into something production compatible if desired.
   #
 
-  synced:
-    image: runner
-    build:
-      context: ./runner
-    volumes:
-      - /data/bitcoin_bench:/bitcoin/data
-    command: >
-      /bitcoin/src/bitcoind -datadir=/bitcoin/data -printtoconsole -noconnect -listen=1 -maxtipage=9999999999999999999999999
-
   bench:
     image: runner
     build:
-      context: ./runner
+      context: .
+      dockerfile: ./runner/Dockerfile
     environment:
       - BITCOIND_STOPATHEIGHT=230000
       - IBD_PEER_ADDRESS=synced
@@ -32,12 +24,18 @@ services:
       - MAKE_JOBS=5
       - COMPILERS=clang
       - BENCHES_TO_RUN=gitclone,build,ibd,reindex
-      # - CHECKOUT_COMMIT=84d5a6210c9c73c3e03d8b024887553051500b92
       # Set minimumchainwork low so that we actually latch out of IBD at low
       # heights.
       - SYNCED_BITCOIND_ARGS=-minimumchainwork=0x00
     volumes:
       - .:/code
+
+  synced:
+    image: runner
+    volumes:
+      - /data/bitcoin_bench:/bitcoin/data
+    command: >
+      /bitcoin/src/bitcoind -datadir=/bitcoin/data -printtoconsole -noconnect -listen=1 -maxtipage=9999999999999999999999999
 
   codespeed:
     build:

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:9-slim
 
-COPY provision /usr/bin/provision
+COPY runner/provision /usr/bin/provision
 RUN /usr/bin/provision
 RUN git clone -b v0.16.1 https://github.com/bitcoin/bitcoin.git /bitcoin
 WORKDIR /bitcoin
@@ -12,5 +12,6 @@ RUN ./contrib/install_db4.sh . && \
   make -j $(($(nproc) - 1))
 
 WORKDIR /code
-COPY * /code/
-RUN pip3 install -r requirements.txt
+COPY setup.py /code/
+COPY runner /code/runner
+RUN pip3 install --upgrade -e . && pip3 install nose

--- a/runner/output.py
+++ b/runner/output.py
@@ -1,0 +1,64 @@
+import datetime
+import pytablewriter
+import sys
+from collections import defaultdict, namedtuple
+
+
+def format_val(bench_name, val):
+    if 'mem-usage' in bench_name:
+        return "%sMiB" % (int(val) / 1000.)
+    else:
+        return str(datetime.timedelta(seconds=float(val)))
+
+
+def get_times_table(name_to_times_map):
+    timestr = "\n"
+    for name, times in sorted(name_to_times_map.items()):
+        for time_ in times:
+            timestr += "{0}: {1}\n".format(name, format_val(name, time_))
+
+    return timestr
+
+
+class BenchVal(namedtuple('BenchVal', 'name,values')):
+    @property
+    def count(self): return len(self.values)
+
+    @property
+    def avg(self): return sum(self.values) / self.count
+
+
+def print_comparative_times_table(commits_to_benches, pfile=sys.stdout):
+    print(file=pfile)
+    writer = pytablewriter.MarkdownTableWriter()
+    vs_str = ("{}" + (" vs. {}" * (len(commits_to_benches) - 1))).format(
+        *commits_to_benches.keys())
+    writer.table_name = vs_str + " (absolute)"
+    writer.header_list = ["name", "iterations", *commits_to_benches.keys()]
+    writer.value_matrix = []
+    writer.margin = 1
+    writer.stream = pfile
+
+    bench_rows = defaultdict(list)
+
+    for commit, benches in commits_to_benches.items():
+        for bench, values in sorted(benches.items()):
+            bench_rows[bench].append(BenchVal(bench, values))
+
+    for bench, row in bench_rows.items():
+        writer.value_matrix.append(
+            [bench, row[0].count, *[r.avg for r in row]])
+
+    writer.write_table()
+    print(file=pfile)
+
+    writer.table_name = vs_str + " (relative)"
+    writer.value_matrix = []
+
+    for bench, row in bench_rows.items():
+        minval = min([r.avg for r in row])
+        normrow = [i.avg / minval for i in row]
+        writer.value_matrix.append(
+            [bench, row[0].count, *normrow])
+
+    writer.write_table()

--- a/runner/requirements.txt
+++ b/runner/requirements.txt
@@ -1,1 +1,2 @@
 requests
+pytablewriter

--- a/runner/test_output.py
+++ b/runner/test_output.py
@@ -1,0 +1,41 @@
+from . import output
+
+from io import StringIO
+from textwrap import dedent
+
+
+def test_print_comparative_times_table():
+    strio = StringIO()
+
+    output.print_comparative_times_table(
+        {'a': {'bench1': [1, 2, 3]}, 'b': {'bench1': [2, 3, 3]}},
+        strio)
+
+    assert strio.getvalue() == dedent(
+        """
+        # a vs. b (absolute)
+        |  name  | iterations |  a  |   b   |
+        |--------|-----------:|----:|------:|
+        | bench1 |          3 |   2 | 2.667 |
+
+
+        # a vs. b (relative)
+        |  name  | iterations |  a  |   b   |
+        |--------|-----------:|----:|------:|
+        | bench1 |          3 |   1 | 1.333 |
+
+        """
+    )
+
+
+def test_print_times_table():
+    assert output.get_times_table(
+        {'a': [1, 2, 3], 'foo': [2.3], 'b.mem-usage': [3000]}) == dedent(
+            """
+            a: 0:00:01
+            a: 0:00:02
+            a: 0:00:03
+            b.mem-usage: 3.0MiB
+            foo: 0:00:02.300000
+            """
+        )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+import os
+
+here = os.path.abspath(os.path.dirname(__file__))
+namespace = {}
+
+setup(
+    name='bitcoinperf',
+    version='0.0.1',
+    description="Bitcoin performance benchmarking tools",
+    author='jamesob',
+    author_email='jamesob@chaincode.com',
+    py_modules=['runner'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=open(os.path.join(
+        here, 'runner', 'requirements.txt')).readlines(),
+    entry_points={
+        'console_scripts': [
+            'bitcoinperf = runner.main:main',
+        ],
+    },
+)


### PR DESCRIPTION
Splits output logic into a separate file, introduces a setup.py and
the `bitcoinperf` command (vs. invoking run_bench.py directly).