### PR TITLE
Revert "runner: Exclude rpc_bind test for now"

### DIFF
--- a/runner/main.py
+++ b/runner/main.py
@@ -478,7 +478,7 @@ def bench_makecheck():
 def bench_functests():
     _try_execute_and_report(
         'functionaltests.%s' % RUN_DATA.compiler,
-        "./test/functional/test_runner.py --exclude rpc_bind",
+        "./test/functional/test_runner.py",
         num_tries=3, executable='functional-test-runner')
 
 


### PR DESCRIPTION
This reverts commit b7f49b1daf2572da3cf611d901b28811a2d8ea23.

Should only be merged after https://github.com/bitcoin/bitcoin/pull/14861 is merged