### PR TITLE
Remove num_jobs from microbench

### DIFF
--- a/examples/pr_compare.yml
+++ b/examples/pr_compare.yml
@@ -27,7 +27,7 @@ benches:
     num_jobs: 4
 
   microbench:
-    num_jobs: 4
+    enabled: true
 
   ibd_range_from_local:
     run_count: 3

--- a/examples/prod.yml
+++ b/examples/prod.yml
@@ -29,7 +29,7 @@ benches:
     num_jobs: 1
 
   microbench:
-    num_jobs: 1
+    enabled: true
 
   ibd_from_local:
     run_count: 1

--- a/examples/smoketest.yml
+++ b/examples/smoketest.yml
@@ -44,7 +44,6 @@ benches:
     num_jobs: 4
 
   microbench:
-    num_jobs: 4
     filter: SHA.*|M.*
 
   ibd_from_network:

--- a/runner/benchmarks.py
+++ b/runner/benchmarks.py
@@ -227,7 +227,7 @@ class FunctionalTests(Benchmark):
 
 class Microbench(Benchmark):
     name = 'microbench'
-    id_format = 'micro.{G.compiler}.j={bench_cfg.num_jobs}'
+    id_format = 'micro.{G.compiler}'
     _results_class = results.MicrobenchResults
 
     def _run(self, cfg, bench_cfg):

--- a/runner/config.py
+++ b/runner/config.py
@@ -172,7 +172,6 @@ class BenchFunctests(Bench):
 
 
 class BenchMicrobench(Bench):
-    num_jobs: t.Op[PositiveInt] = DEFAULT_NPROC
     filter: str = ''
 
 


### PR DESCRIPTION
This is unused, but it might break the production database because the bench name is changed?