### PR TITLE
Cache simplification & fixes

### DIFF
--- a/examples/smoketest.yml
+++ b/examples/smoketest.yml
@@ -1,12 +1,5 @@
 ---
 
-# Cache a built bitcoin src directory and restore it from the cache on
-# subsequent runs.
-cache_build: true
-
-# If true, the first git clone will be cached and copied from as necessary.
-cache_git: true
-
 # Set to false to make cache dropping optional and bypass various safety checks.
 safety_checks: false
 
@@ -24,6 +17,8 @@ synced_peer:
   
   # address: tanoshii.local:8333
 
+
+teardown: false
 
 codespeed:
   url: http://codespeed:8000

--- a/runner/benchmarks.py
+++ b/runner/benchmarks.py
@@ -547,6 +547,7 @@ class _IbdBench(Benchmark):
             self.server_node.stop_via_rpc(timeout=120)
 
         # Copy logfile to results
+        datadirpath = self._get_datadir_path()
         debuglogpath = self._get_datadir_path() / 'debug.log'
         if debuglogpath.exists():
             shutil.copyfile(
@@ -564,16 +565,18 @@ class _IbdBench(Benchmark):
                 return
 
             if self.bench_cfg.stash_datadir.exists():
-                shutil.rmtree(self.bench_cfg.stash_datadir)
+                logger.warning(
+                    "removing existing stash_datadir (%s)",
+                    self.bench_cfg.stash_datadir)
+                sh.rm(self.bench_cfg.stash_datadir)
 
-            (self.cfg.workdir / 'data').replace(self.bench_cfg.stash_datadir)
+            shutil.move(datadirpath, self.bench_cfg.stash_datadir)
             logger.info("Stashed datadir from %s -> %s",
-                        self.cfg.workdir / 'data',
-                        self.bench_cfg.stash_datadir)
+                        datadirpath, self.bench_cfg.stash_datadir)
         else:
-            datadir = self.cfg.workdir / 'data'
-            if datadir.exists():
-                shutil.rmtree(datadir)
+            if datadirpath.exists():
+                logger.info(f"removing datadir at {datadirpath}")
+                shutil.rmtree(datadirpath)
 
 
 class IbdLocal(_IbdBench):

--- a/runner/config.py
+++ b/runner/config.py
@@ -298,14 +298,13 @@ class Target(BaseModel):
     # commit.
     gitco: Op[GitCheckout] = None
 
-    @property
-    def cache_key(self):
+    def cache_key(self, compiler: Compilers):
         """
         A unique, shortish identifier suitable for use as an ID in a cache.
 
         TODO unittest this
         """
-        sha = util.sha256(self._hash_str)
+        sha = util.sha256(self._hash_str + str(compiler))
         ref = re.sub('[^0-9a-zA-Z]', '-', self.gitref[:16])
         return f'{ref}-{sha[:16]}'
 

--- a/runner/config.py
+++ b/runner/config.py
@@ -348,8 +348,6 @@ class Config(BaseModel):
     teardown: bool = True
     safety_checks: bool = True
     clean: bool = True
-    cache_build: bool = False
-    cache_git: bool = False
     cache_build_size: int = 3
     codespeed: Op[Codespeed] = None
     benches: Op[Benches] = None

--- a/runner/main.py
+++ b/runner/main.py
@@ -77,10 +77,12 @@ def _cleanup_tmpfiles():
     sh.run(r'find /tmp/test_runner_* -mtime +3 -exec rm -rf {} \;')
 
 
-def run_full_suite(cfg):
+def run_full_suite(cfg) -> bool:
     """
     Create a tmp directory in which we will clone bitcoin, build it, and run
     various benchmarks.
+
+    Return whether we successfully completed the run.
     """
     logger.info(
         "Running benchmarks %s with compilers %s",
@@ -95,7 +97,7 @@ def run_full_suite(cfg):
 
     if bad_targets:
         logger.warning("Couldn't resolve git targets: %s", bad_targets)
-        return
+        return False
 
     config.link_latest_run(cfg)
 
@@ -141,6 +143,8 @@ def run_full_suite(cfg):
         maybe_run_bench_some_times(
             target, cfg, compiler,
             cfg.benches.reindex_chainstate, benchmarks.ReindexChainstate)
+
+    return True
 
 
 def maybe_run_bench_some_times(
@@ -587,16 +591,19 @@ def run(yaml_filename: Path):
     logger.info(cfg.to_string(pretty=True))
 
     try:
-        run_full_suite(cfg)
+        completed = run_full_suite(cfg)
     except Exception:
         G.slack.send_to_slack_attachment(
             G.gitco, "Error", {},
             text=traceback.format_exc(), success=False)
         raise
 
-    _persist_results(cfg, results.ALL_RUNS)
-    _print_results()
-
+    if completed:
+        _persist_results(cfg, results.ALL_RUNS)
+        _print_results()
+    else:
+        print("run failed")
+        sys.exit(1)
 
 def _persist_results(cfg, results):
     logger.info("Getting hardware information")

--- a/runner/main.py
+++ b/runner/main.py
@@ -188,9 +188,9 @@ def _get_shutdown_handler(cfg: config.Config):
             # For now only remove the bitcoin subdir, since that'll be far and
             # away the biggest subdir.
             sh.run("rm -rf %s" % (cfg.workdir / 'bitcoin'))
-            logger.debug("shutdown: removed bitcoin dir at %s", cfg.workdir)
+            logger.info("shutdown: removed bitcoin dir at %s", cfg.workdir)
         elif not cfg.teardown:
-            logger.debug("shutdown: leaving bitcoin dir at %s", cfg.workdir)
+            logger.info("shutdown: leaving bitcoin dir at %s", cfg.workdir)
 
     return handler
 

--- a/runner/sh.py
+++ b/runner/sh.py
@@ -46,6 +46,7 @@ def cd(*args, **kwargs):
 
 
 def rm(path: Path):
+    """Polymorphic rm of file objects."""
     logger.debug(f"rm {path}")
     if path.is_symlink():
         path.unlink()


### PR DESCRIPTION
Instead of trying to be smart with selective caching of the contents of `bitcoin/` (and subsequently introducing exceptions thrown in production), just cache the whole darn directory. It's a few hundred megabytes, but on these environments nobody should be worrying about that amount of disk space

During development of benchula (i.e. emphasis on the `bench-pr` functionality), the "bench a single branch" path sort of fell behind, so there are a few miscellaneous fixes here intended to get bitcoinperf.com back into fighting shape.