### PR TITLE
Add chain regions framework

### DIFF
--- a/bin/compress-datadir.sh
+++ b/bin/compress-datadir.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+if [ $# -lt "2" ]; then
+    echo "Usage: <datadir-path-to-compress> <name-of-output>"
+fi
+
+tar -czvf ${2}.tar.gz -C ${1} .

--- a/bin/compress-datadir.sh
+++ b/bin/compress-datadir.sh
@@ -3,6 +3,7 @@
 
 if [ $# -lt "2" ]; then
     echo "Usage: <datadir-path-to-compress> <name-of-output>"
+    exit 1
 fi
 
 tar -czvf ${2}.tar.gz -C ${1} .

--- a/examples/ctv.yml
+++ b/examples/ctv.yml
@@ -1,0 +1,47 @@
+---
+
+# Cache a built bitcoin src directory and restore it from the cache on
+# subsequent runs.
+cache_build: true
+
+# If true, the first git clone will be cached and copied from as necessary.
+cache_git: true
+
+# Set to false to make cache dropping optional and bypass various safety checks.
+safety_checks: false
+
+compilers:
+  - gcc
+
+synced_peer:
+  datadir: /data2/bitcoin
+  repodir: /home/james/src/bitcoinbench
+  bitcoind_extra_args: ''
+
+  # or, if over network
+  #
+  # address:
+
+
+benches:
+  build:
+    num_jobs: 15
+  
+  ibd_range_from_local:
+    run_count: 3
+    start_height: 667_200
+    end_height: 700_000
+    src_datadir: /home/james/.bitcoinperf/base_datadirs/pruned-667200
+
+
+to_bench:
+
+  - gitref: bench/ctv
+    gitremote: jamesob
+    bitcoind_extra_args: '-dbcache=8000 -assumevalid=0'
+    rebase: false
+
+  - gitref: $mergebase
+    bitcoind_extra_args: '-dbcache=8000 -assumevalid=0'
+    rebase: false
+

--- a/runner/git.py
+++ b/runner/git.py
@@ -218,7 +218,7 @@ def resolve_targets(repo_path: Path,
 
             pre_rebase_sha = sha
             sha = get_sha('HEAD')
-            logger.info("Rebased %s (%s) on top of origin/master (%s): %r",
+            logger.info("Rebased %s (%s) on top of origin/master (%s): %s",
                         tar.gitref, pre_rebase_sha, get_sha('origin/master'), sha)
 
         msg = get_commit_msg(sha)
@@ -237,11 +237,11 @@ def resolve_targets(repo_path: Path,
 
 
 def get_sha(ref: str) -> str:
-    return sh.run(f'git rev-parse {ref}').stdout.strip()
+    return sh.run(f'git rev-parse {ref}', check=True).stdout.strip()
 
 
 def get_commit_msg(ref: str) -> str:
-    return sh.run(f'git log -1 --pretty=%B {ref}').stdout.strip()
+    return sh.run(f'git log -1 --pretty=%B {ref}', check=True).stdout.strip()
 
 
 def get_git_mergebase(repo_path: Path, remote: str, name: str) -> str:


### PR DESCRIPTION
This change more easily supports different "chain regions" (i.e. prebuilt pruned datadirs) that allow us to do IBD benchmarks on a selected region of the mainchain. It updates the default region from one starting at height 500_000 (before segwit activation) to one that starts at height 667_200 (about a year ago).

This new region is more characteristic of validation behavior going forward since it contains a higher proportion of segwit spends.

The new region has been uploaded to Google Cloud for easy download during `bitcoinperf setup`: https://storage.googleapis.com/chaincode-bitcoinperf/pruned_667200.tar.gz